### PR TITLE
Try to use gosu, not sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
         locales \
         procps \
         python \
-        sudo \
+        gosu \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/iobroker_startup.sh
+++ b/scripts/iobroker_startup.sh
@@ -39,6 +39,9 @@ then
 	echo 'Restoring done...'
 fi
 
+# Change sudo to gosu
+sed -i 's/sudo -H -u/gosu/g' /opt/iobroker/iobroker
+
 # Checking for first run of a new installation and renaming ioBroker
 if [ -f /opt/iobroker/.install_host ]
 then


### PR DESCRIPTION
As docker recommanded, do not use sudo, use gosu instead.
This can fix the issue that can not use net =host in synology.

You can try the image jimus.iobroker:synology with this PR

Signed-off-by: SchumyHao <schumyhaojl@126.com>