### PR TITLE
Node upgrade, fix link / add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ Feel free to ask for more architectures by opening an github-issue.
 ## Important
 
 The new v4 comes again with a new major node-version (node10)!
-If you are updating an existing Installation you have to perform some additional steps inside ioBroker!
+If you are updating an existing installation you have to perform some additional steps inside ioBroker!
 After upgrading your iobroker-container you have to call "reinstall.sh" for recompiling your installation for the use with node10!
-For Details see official ioBroker-documentation (http://www.iobroker.net/docu/?page_id=8323&lang=de). Make backup first!
+
+```bash
+# update the $CONTAINER_ID below!
+docker exec -it $CONTAINER_ID node ./reinstall.js
+```
+
+For Details see official ioBroker-documentation (https://www.iobroker.net/#en/documentation/install/updatenode.md). Make backup first!
 
 ## Installation & usage
 


### PR DESCRIPTION
I can only guess to where the original link pointed to. Replaced it with the docs page for upgrading node.

Also added an example, how to run reinstall in the container.